### PR TITLE
fix(about-page)📱: improve mobile responsiveness for profile and social icons

### DIFF
--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -4,7 +4,7 @@ layout: default
 <div class="post">
   <article>
     {% if page.profile %}
-      <div class="profile float-{% if page.profile.align == 'left' %}left{% else %}right{% endif %}" style="padding: 10px; display: flex; flex-direction: column; align-items: center; margin-right: 60px;">
+      <div class="profile float-{% if page.profile.align == 'left' %}left{% else %}right{% endif %}" style="padding: 10px; display: flex; flex-direction: column; align-items: center;">
         <div style="padding: 5px; margin-bottom: 0.1rem; text-align: center;">
         {% if page.profile.image %}
           {% assign profile_image_path = page.profile.image | prepend: 'assets/img/' %}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -202,6 +202,55 @@ blockquote {
   margin-right: 2rem;
 }
 
+// Mobile-specific styles (screens smaller than 576px)
+@media (max-width: 575px) {
+  .profile {
+    min-width: unset !important;
+    max-width: 100% !important;
+    width: 100% !important;
+    margin: 0 auto !important;
+    padding: 10px !important;
+    float: none !important;
+
+    img {
+      width: 90% !important;
+      max-width: 90% !important;
+      margin: 0 auto !important;
+      display: block !important;
+    }
+  }
+
+  .post article .profile {
+    display: flex !important;
+    flex-direction: column !important;
+    align-items: center !important;
+    text-align: center !important;
+  }
+
+  .social {
+    width: 100% !important;
+    margin: 1rem auto 0 auto !important;
+    padding: 0 !important;
+    text-align: center !important;
+
+    .contact-icons {
+      display: flex !important;
+      justify-content: center !important;
+      align-items: center !important;
+      flex-wrap: wrap !important;
+      gap: 1rem !important;
+    }
+  }
+
+  .post article {
+    display: block !important;
+  }
+
+  .post article .clearfix {
+    margin-left: 0 !important;
+  }
+}
+
 @media (min-width: 576px) {
   .profile {
     width: auto !important;


### PR DESCRIPTION
- Add mobile-specific CSS media query for screens < 576px
- Center profile image on mobile and increase size to 90% width
- Center social icons with proper flex layout
- Remove inline margin-right that was causing left-shift on mobile
- Preserve desktop appearance (screens >= 576px) unchanged